### PR TITLE
feat : 宇宙人のアウトラインの作成、母艦の移動修正

### DIFF
--- a/Biritako-Boom/Assets/Materials/OutLine.mat
+++ b/Biritako-Boom/Assets/Materials/OutLine.mat
@@ -1,0 +1,55 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 8
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: OutLine
+  m_Shader: {fileID: 4800000, guid: 0691f2b8d39296e4bad9a0f094652c45, type: 3}
+  m_Parent: {fileID: 0}
+  m_ModifiedSerializedProperties: 0
+  m_ValidKeywords:
+  - PIXELSNAP_ON
+  m_InvalidKeywords: []
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 1
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_LockedProperties: 
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _AlphaTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MaskTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _NormalMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Ints: []
+    m_Floats:
+    - PixelSnap: 1
+    - _EnableExternalAlpha: 0
+    - _OutLineSpread: 0.0052
+    - _Smoothness: 0
+    - _ZWrite: 0
+    m_Colors:
+    - _Color: {r: 1, g: 1, b: 1, a: 1}
+    - _OutLineColor: {r: 1, g: 0, b: 0, a: 1}
+    - _RendererColor: {r: 1, g: 1, b: 1, a: 1}
+  m_BuildTextureStacks: []
+  m_AllowLocking: 1

--- a/Biritako-Boom/Assets/Materials/OutLine.mat.meta
+++ b/Biritako-Boom/Assets/Materials/OutLine.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: cac3cd07d6d3b0d4b8cbcd1729b952ee
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Biritako-Boom/Assets/Prefabs/Enemies/Enemy_Alien.prefab
+++ b/Biritako-Boom/Assets/Prefabs/Enemies/Enemy_Alien.prefab
@@ -151,7 +151,7 @@ SpriteRenderer:
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
-  - {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
+  - {fileID: 2100000, guid: cac3cd07d6d3b0d4b8cbcd1729b952ee, type: 2}
   m_StaticBatchInfo:
     firstSubMesh: 0
     subMeshCount: 0
@@ -173,7 +173,7 @@ SpriteRenderer:
   m_SortingLayer: 1
   m_SortingOrder: 0
   m_Sprite: {fileID: -79376298, guid: fc4bb2110acda554a93564273c799e14, type: 3}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_Color: {r: 1, g: 0, b: 0.53201437, a: 1}
   m_FlipX: 0
   m_FlipY: 0
   m_DrawMode: 0

--- a/Biritako-Boom/Assets/Scripts/InGame/Model/MotherShipModel.cs
+++ b/Biritako-Boom/Assets/Scripts/InGame/Model/MotherShipModel.cs
@@ -275,11 +275,17 @@ namespace InGame.Model
             // リスト内の破壊されたUFO（nullになったもの）を安全に削除
             _ufoTargets.RemoveAll(target => target == null || !target.activeInHierarchy);
 
-            // 全ての雑魚UFOが破壊された場合、中央への移動状態に遷移します
+            // 全ての雑魚UFOが破壊された場合、再度索敵を試みる
             if (_ufoTargets.Count == 0)
             {
-                _currentState = State.MovingToCenter; 
-                return;
+                FindTargets(); // ターゲットを再検索
+                
+                // それでもターゲットが見つからなければ、中央への移動状態に遷移します
+                if (_ufoTargets.Count == 0)
+                {
+                    _currentState = State.MovingToCenter; 
+                    return;
+                }
             }
             
             // ターゲットインデックスがリストの範囲を超えるのを防ぐ

--- a/Biritako-Boom/Assets/Scripts/Shader/SpritesOutline.shader
+++ b/Biritako-Boom/Assets/Scripts/Shader/SpritesOutline.shader
@@ -1,0 +1,115 @@
+
+Shader "Sprites/Outline"
+{
+	Properties
+	{
+		[PerRendererData] _MainTex ("Sprite Texture", 2D) = "white" {}
+		[MaterialToggle] PixelSnap ("Pixel snap", Float) = 0
+		_OutLineSpread ("Outline Spread", Range(0, 0.1)) = 0
+		_OutLineColor ("Outline Color", Color) = (1, 1, 1, 1)
+		_Smoothness ("Outline Smoothness", Range(0, 0.5)) = 0.1
+	}
+
+	SubShader
+	{
+		Tags
+		{ 
+			"Queue"="Transparent" 
+			"IgnoreProjector"="True" 
+			"RenderType"="Transparent" 
+			"PreviewType"="Plane"
+			"CanUseSpriteAtlas"="True"
+		}
+
+		Cull Off
+		Lighting Off
+		ZWrite Off
+		Fog { Mode Off }
+		Blend SrcAlpha OneMinusSrcAlpha
+
+		Pass
+		{
+		CGPROGRAM
+			#pragma vertex vert
+			#pragma fragment frag
+			#pragma multi_compile DUMMY PIXELSNAP_ON
+			#include "UnityCG.cginc"
+			
+			struct appdata
+			{
+				float4 vertex   : POSITION;
+				float4 color    : COLOR;
+				float2 texcoord : TEXCOORD0;
+			};
+
+			struct v2f
+			{
+				float4 vertex	: SV_POSITION;
+				fixed4 color    : COLOR;
+				float2 texcoord : TEXCOORD0;
+			};
+			
+			sampler2D _MainTex;
+			half _OutLineSpread;
+			fixed4 _OutLineColor;
+			fixed _Smoothness;
+
+			v2f vert(appdata IN)
+			{
+				fixed scale = 1 + _OutLineSpread * 2;
+
+				float2 tex = IN.texcoord * scale;
+				tex -= (scale - 1) / 2;
+
+				v2f OUT;
+				OUT.vertex = UnityObjectToClipPos(IN.vertex);
+				OUT.texcoord = tex;
+				OUT.color = IN.color;
+				#ifdef PIXELSNAP_ON
+				OUT.vertex = UnityPixelSnap (OUT.vertex);
+				#endif
+
+				return OUT;
+			}
+
+			sampler2D _AlphaTex;
+			float _AlphaSplitEnabled;
+
+			fixed4 SampleSpriteTexture (float2 uv)
+			{
+				fixed4 color = tex2D (_MainTex, uv);
+
+#if UNITY_TEXTURE_ALPHASPLIT_ALLOWED
+				if (_AlphaSplitEnabled)
+				{
+					color.a = tex2D (_AlphaTex, uv).r;
+				}
+#endif
+
+				return color;
+			}
+
+			fixed4 frag(v2f IN) : SV_Target
+			{
+				fixed4 base = SampleSpriteTexture(IN.texcoord) * IN.color;
+
+				fixed4 out_col = _OutLineColor;
+				out_col.a = 1;
+				half2 line_w = half2(_OutLineSpread, 0);
+				fixed4 line_col = SampleSpriteTexture(IN.texcoord + line_w.xy)
+							    + SampleSpriteTexture(IN.texcoord - line_w.xy)
+								+ SampleSpriteTexture(IN.texcoord + line_w.yx)
+								+ SampleSpriteTexture(IN.texcoord - line_w.yx);
+				out_col *= line_col.a;
+				out_col.rgb = _OutLineColor.rgb;
+				out_col = lerp(base, out_col, max(0, sign(_OutLineSpread)));
+
+				fixed4 main_col = base;
+				main_col = lerp(main_col, out_col, (1 - main_col.a));
+				main_col.a = IN.color.a * max(0, sign(main_col.a - _Smoothness));
+				return main_col;
+			}
+		ENDCG
+		}
+	}
+}

--- a/Biritako-Boom/Assets/Scripts/Shader/SpritesOutline.shader.meta
+++ b/Biritako-Boom/Assets/Scripts/Shader/SpritesOutline.shader.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: d1a475b33f3ab604ca3451659943f185
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Biritako-Boom/Assets/Scripts/Shader/SpritesOutlineColor.shader
+++ b/Biritako-Boom/Assets/Scripts/Shader/SpritesOutlineColor.shader
@@ -1,0 +1,110 @@
+Shader "Sprites/OutlineColor"
+{
+	Properties
+	{
+		[PerRendererData] _MainTex ("Sprite Texture", 2D) = "white" {}
+		_Color ("Tint", Color) = (1,1,1,1)
+		[MaterialToggle] PixelSnap ("Pixel snap", Float) = 0
+		_OutLineSpread ("Outline Spread", Range(0, 0.1)) = 0
+		_Smoothness ("Outline Smoothness", Range(0, 0.5)) = 0
+	}
+
+	SubShader
+	{
+		Tags
+		{ 
+			"Queue"="Transparent" 
+			"IgnoreProjector"="True" 
+			"RenderType"="Transparent" 
+			"PreviewType"="Plane"
+			"CanUseSpriteAtlas"="True"
+		}
+
+		Cull Off
+		Lighting Off
+		ZWrite Off
+		Fog { Mode Off }
+		Blend SrcAlpha OneMinusSrcAlpha
+
+		Pass
+		{
+		CGPROGRAM
+			#pragma vertex vert
+			#pragma fragment frag
+			#pragma multi_compile DUMMY PIXELSNAP_ON
+			#include "UnityCG.cginc"
+			
+			struct appdata
+			{
+				float4 vertex   : POSITION;
+				float4 color    : COLOR;
+				float2 texcoord : TEXCOORD0;
+			};
+
+			struct v2f
+			{
+				float4 vertex	: SV_POSITION;
+				fixed4 color    : COLOR;
+				float2 texcoord : TEXCOORD0;
+			};
+			
+			sampler2D _MainTex;
+			fixed4 _Color;
+			half _OutLineSpread;
+			fixed _Smoothness;
+
+			v2f vert(appdata IN)
+          {
+             v2f OUT;
+             OUT.vertex = UnityObjectToClipPos(IN.vertex);
+             // 元のテクスチャ座標をそのままフラグメントシェーダーに渡す
+             OUT.texcoord = IN.texcoord; 
+             OUT.color = IN.color;
+             #ifdef PIXELSNAP_ON
+             OUT.vertex = UnityPixelSnap (OUT.vertex);
+             #endif
+
+             return OUT;
+          }
+
+			sampler2D _AlphaTex;
+			float _AlphaSplitEnabled;
+
+			fixed4 SampleSpriteTexture (float2 uv)
+			{
+				fixed4 color = tex2D (_MainTex, uv);
+
+#if UNITY_TEXTURE_ALPHASPLIT_ALLOWED
+				if (_AlphaSplitEnabled)
+				{
+					color.a = tex2D (_AlphaTex, uv).r;
+				}
+#endif
+
+				return color;
+			}
+
+			fixed4 frag(v2f IN) : SV_Target
+			{
+				fixed4 base = SampleSpriteTexture(IN.texcoord);
+				base.rgb *= _Color.rgb;
+
+				fixed4 out_col = IN.color;
+				out_col.a = 1;
+				half2 line_w = half2(_OutLineSpread, 0);
+				fixed4 line_col = SampleSpriteTexture(IN.texcoord + line_w.xy)
+							    + SampleSpriteTexture(IN.texcoord - line_w.xy)
+								+ SampleSpriteTexture(IN.texcoord + line_w.yx)
+								+ SampleSpriteTexture(IN.texcoord - line_w.yx);
+				out_col.a *= line_col.a;
+				out_col = lerp(base, out_col, max(0, sign(_OutLineSpread)));
+
+				fixed4 main_col = base;
+				main_col = lerp(main_col, out_col, (1 - main_col.a));
+				main_col.a = IN.color.a * max(0, sign(main_col.a - _Smoothness));
+				return main_col;
+			}
+		ENDCG
+		}
+	}
+}

--- a/Biritako-Boom/Assets/Scripts/Shader/SpritesOutlineColor.shader.meta
+++ b/Biritako-Boom/Assets/Scripts/Shader/SpritesOutlineColor.shader.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 0691f2b8d39296e4bad9a0f094652c45
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
# 概要
- 宇宙人のアウトライン作成
- 母艦の移動修正

## 宇宙人のアウトライン作成
アウトラインの色だとか、太さは変えれます。
色は宇宙人のプレハブ自体の色(Sprite rendererの奴)
太さはマテリアルで変えれます

## 母艦の移動修正
雑魚UFOがいるのにいなくなった時の行動をするのを直しました(自分のPCでは再発しませんでした)

問題として雑魚UFOが生成途中に母艦がリスト作成している可能性があったので、雑魚UFOがいなくなったタイミングで再度リスト取得を行います